### PR TITLE
Fix: Resolve quick preset buttons causing black screen (Issue #13)

### DIFF
--- a/src/studio/backgrounds/GradientBackground.ts
+++ b/src/studio/backgrounds/GradientBackground.ts
@@ -99,7 +99,8 @@ export class GradientBackground {
   }
 
   updateConfig(config: Partial<GradientConfig>): void {
-    Object.assign(this.config, config);
+    // Create a new config object to avoid modifying readonly properties
+    this.config = { ...this.config, ...config };
 
     if (this.material instanceof THREE.ShaderMaterial && this.material.uniforms) {
       if (config.colors) {

--- a/src/studio/backgrounds/NeuralNetworkBackground.ts
+++ b/src/studio/backgrounds/NeuralNetworkBackground.ts
@@ -491,7 +491,8 @@ export class NeuralNetworkBackground {
   }
 
   updateConfig(config: Partial<AnimatedConfig>): void {
-    Object.assign(this.config, config);
+    // Create a new config object to avoid modifying readonly properties
+    this.config = { ...this.config, ...config };
 
     if (!config.neural) return;
 

--- a/src/studio/backgrounds/ParticleSystem.ts
+++ b/src/studio/backgrounds/ParticleSystem.ts
@@ -87,7 +87,8 @@ export class ParticleSystem {
   }
 
   updateConfig(config: Partial<ParticleConfig>): void {
-    Object.assign(this.config, config);
+    // Create a new config object to avoid modifying readonly properties
+    this.config = { ...this.config, ...config };
 
     if (this.material) {
       if (config.color) {

--- a/src/studio/backgrounds/SolidBackground.ts
+++ b/src/studio/backgrounds/SolidBackground.ts
@@ -36,7 +36,8 @@ export class SolidBackground {
   }
 
   updateConfig(config: Partial<SolidConfig>): void {
-    Object.assign(this.config, config);
+    // Create a new config object to avoid modifying readonly properties
+    this.config = { ...this.config, ...config };
 
     // Update material color if it changed
     if (config.color && this.material) {

--- a/src/studio/backgrounds/WavesBackground.ts
+++ b/src/studio/backgrounds/WavesBackground.ts
@@ -145,7 +145,8 @@ export class WavesBackground {
   }
 
   updateConfig(config: Partial<AnimatedConfig>): void {
-    Object.assign(this.config, config);
+    // Create a new config object to avoid modifying readonly properties
+    this.config = { ...this.config, ...config };
 
     if (!this.material || !this.material.uniforms || !config.waves) return;
 


### PR DESCRIPTION
## Summary

Fixes the "Cannot assign to read only property 'colors'" error that occurs when clicking quick preset buttons in the background controls, which was causing the screen to go black until page refresh.

## Problem

When users clicked quick presets (like "Purple Haze" for gradients or "Blue Screen" for solid colors), the application would throw a TypeError and display a black screen. The issue was caused by `Object.assign(this.config, config)` attempting to modify readonly/frozen properties on config objects that come from the Zustand store (which uses Immer for immutability).

## Solution

Replaced all instances of `Object.assign(this.config, config)` with `this.config = { ...this.config, ...config }` in background classes. This creates a new config object instead of trying to mutate the existing one, preventing the readonly property assignment error.

## Files Changed

- **GradientBackground.ts** - Fixed updateConfig method
- **SolidBackground.ts** - Fixed updateConfig method  
- **ParticleSystem.ts** - Fixed updateConfig method
- **WavesBackground.ts** - Fixed updateConfig method
- **NeuralNetworkBackground.ts** - Fixed updateConfig method

## Testing

✅ Application builds successfully  
✅ Development server starts without errors  
✅ All background types now use consistent config update pattern  
✅ No remaining `Object.assign(this.config, config)` patterns in background files  

## Test Plan

To test this fix:

1. Navigate to `/app` in the application
2. Try clicking various quick presets:
   - **Gradient backgrounds**: "Deep Blue", "Purple Haze", "Sunset", "Ocean"
   - **Solid backgrounds**: "Green Screen", "Blue Screen", "Pure Black", "Pure White"  
   - **Neural backgrounds**: "AI Blue", "Deep Purple", "Cyber Blue", "Matrix Green"
   - **Waves backgrounds**: "Tech Blue", "Warm Sunset", "Ocean Flow", "Matrix Green"
3. Verify that presets apply immediately without black screen or console errors
4. Confirm no page refresh is needed to see the changes

Closes #13

🤖 Generated with [Claude Code](https://claude.ai/code)