### PR TITLE
Fix: Implement Google Analytics exactly per Google specifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { LandingPage } from './pages/LandingPage';
 import { Studio } from './pages/Studio';
@@ -10,37 +10,8 @@ import { useAnalytics } from '@/hooks/useAnalytics';
 import { getEnvironmentConfig } from '@/services/analytics';
 import './App.css';
 
-// Analytics tracking component for route changes
-function AnalyticsTracker() {
-  const location = useLocation();
-  const analytics = useAnalytics();
-
-  useEffect(() => {
-    // Track page view on route change
-    if (analytics.isReady && analytics.hasConsent) {
-      const pageTitle = getPageTitle(location.pathname);
-      analytics.trackPageView(pageTitle, window.location.href);
-    }
-  }, [location.pathname, analytics]);
-
-  return null;
-}
-
-// Get page title based on route
-function getPageTitle(pathname: string): string {
-  switch (pathname) {
-    case '/':
-      return 'Virtual Studio - Home';
-    case '/app':
-      return 'Virtual Studio - Application';
-    case '/feedback':
-      return 'Virtual Studio - Feedback';
-    case '/docs':
-      return 'Virtual Studio - Documentation';
-    default:
-      return 'Virtual Studio';
-  }
-}
+// Note: Page view tracking is now handled automatically by Google Analytics
+// No manual tracking needed with default gtag configuration
 
 // Main app content with analytics
 function AppContent() {
@@ -71,7 +42,6 @@ function AppContent() {
 
   return (
     <>
-      <AnalyticsTracker />
       <Routes>
         <Route path="/" element={<LandingPage />} />
         <Route path="/app" element={<Studio />} />

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -65,9 +65,9 @@ export class AnalyticsServiceImpl implements AnalyticsService {
       // Initialize dataLayer if not exists
       window.dataLayer = window.dataLayer || [];
       
-      // Create gtag function
-      function gtag(...args: any[]): void {
-        window.dataLayer?.push(args);
+      // Create gtag function exactly as Google specifies
+      function gtag(){
+        window.dataLayer?.push(arguments);
       }
       window.gtag = gtag;
       
@@ -76,14 +76,10 @@ export class AnalyticsServiceImpl implements AnalyticsService {
       script.async = true;
       script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`;
       script.onload = () => {
-        // Initialize gtag
+        // Initialize gtag exactly as Google specifies
         if (window.gtag) {
           window.gtag('js', new Date());
-          window.gtag('config', measurementId, {
-            send_page_view: false, // We'll handle page views manually
-            allow_google_signals: false,
-            allow_ad_personalization_signals: false
-          });
+          window.gtag('config', measurementId);
         }
         resolve();
       };


### PR DESCRIPTION
## Summary
Fixed Google Analytics implementation to match Google's standard gtag.js specifications exactly, which should resolve the issue where analytics data wasn't appearing in Google Analytics real-time reports.

## Root Cause Analysis
Our custom implementation had several deviations from Google's standard:
1. **Manual page view tracking disabled**: We set `send_page_view: false` and handled page views manually
2. **Custom config options**: Added `allow_google_signals: false` and `allow_ad_personalization_signals: false`
3. **Complex manual tracking**: Used custom AnalyticsTracker component for route changes

## Changes Made
- **Simplified gtag config**: Now uses `gtag('config', measurementId)` without custom parameters
- **Removed manual page tracking**: Google Analytics handles page views automatically with default config
- **Cleaned up gtag function**: Matches Google's exact specification
- **Removed AnalyticsTracker**: No longer needed with automatic page view tracking
- **Cleaned up imports**: Removed unused components and functions

## Google's Standard Implementation
Our implementation now matches Google's official instructions exactly:
```javascript
window.dataLayer = window.dataLayer || [];
function gtag(){dataLayer.push(arguments);}
gtag('js', new Date());
gtag('config', 'G-167JX9M69Z');
```

## Expected Result
Analytics data should now appear in Google Analytics real-time reports when users visit the site, as our implementation is identical to Google's standard gtag.js setup.

## Test Plan
- [x] Build succeeds without errors
- [x] Analytics initialize on page load with opt-out model
- [x] No console errors related to gtag
- [ ] Verify real-time data appears in Google Analytics dashboard
- [ ] Test that page views are tracked automatically on route changes

🤖 Generated with [Claude Code](https://claude.ai/code)