### PR TITLE
Fix #23: Handle localStorage quota errors so ticker animation toggle works

### DIFF
--- a/src/services/state/defaults.ts
+++ b/src/services/state/defaults.ts
@@ -1,0 +1,16 @@
+import type { StudioBackground, GradientConfig } from '@/types/studio';
+
+export const defaultGradientConfig: GradientConfig = {
+  colors: ['#1a1a2e', '#16213e', '#0f3460'],
+  angle: 135,
+  type: 'linear',
+  animated: true,
+  animationSpeed: 0.5,
+};
+
+export const createDefaultBackground = (): StudioBackground => ({
+  id: 'default-bg',
+  type: 'gradient',
+  visible: true,
+  config: { ...defaultGradientConfig },
+});

--- a/src/services/state/studioStore.ts
+++ b/src/services/state/studioStore.ts
@@ -2,14 +2,14 @@ import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { subscribeWithSelector } from 'zustand/middleware';
 import { localStorageService } from '@services/storage/localStorage';
-import type { 
-  StudioBackground, 
-  LowerThird, 
-  Ticker, 
-  Clock, 
+import { createDefaultBackground } from '@services/state/defaults';
+import type {
+  StudioBackground,
+  LowerThird,
+  Ticker,
+  Clock,
   LiveIndicator,
   StudioPreset,
-  GradientConfig,
   ImageConfig,
   LogoConfig,
   LogoPosition
@@ -79,21 +79,7 @@ interface StudioState {
   toggleLiveIndicator: () => void;
 }
 
-// Default gradient background
-const defaultGradientConfig: GradientConfig = {
-  colors: ['#1a1a2e', '#16213e', '#0f3460'],
-  angle: 135,
-  type: 'linear',
-  animated: true,
-  animationSpeed: 0.5
-};
-
-const defaultBackground: StudioBackground = {
-  id: 'default-bg',
-  type: 'gradient',
-  visible: true,
-  config: defaultGradientConfig
-};
+const defaultBackground: StudioBackground = createDefaultBackground();
 
 const defaultClock: Clock = {
   visible: false,

--- a/src/services/storage/__tests__/localStorage.test.ts
+++ b/src/services/storage/__tests__/localStorage.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { localStorageService, type SavedStudioState } from '@services/storage/localStorage';
+import type { ImageConfig, LogoConfig, StudioBackground } from '@/types/studio';
+
+const largeDataUrl = (sizeKb: number): string =>
+  'data:image/png;base64,' + 'A'.repeat(sizeKb * 1024);
+
+const buildLogo = (id: string, imageUrl: string): LogoConfig => ({
+  id,
+  visible: true,
+  name: id,
+  imageUrl,
+  fileName: `${id}.png`,
+  position: 'bottom-right',
+  size: 150,
+  opacity: 1,
+  offset: { x: 20, y: 20 },
+  uploadTimestamp: 0,
+});
+
+const baseState: SavedStudioState = {
+  background: {
+    id: 'bg-1',
+    type: 'image',
+    visible: true,
+    config: { url: largeDataUrl(400), fit: 'cover', position: { x: 0, y: 0 } } as ImageConfig,
+  } as StudioBackground,
+  lowerThird: null,
+  ticker: {
+    id: 't1',
+    visible: true,
+    content: ['hello'],
+    speed: 50,
+    backgroundColor: '#000',
+    textColor: '#fff',
+    fontSize: 14,
+    animated: true,
+  },
+  clock: {
+    visible: false,
+    showTime: true,
+    format: '12h',
+    timezone: 'UTC',
+    showSeconds: true,
+    showDate: false,
+    dateFormat: 'short',
+    position: { x: 0, y: 0 },
+    style: { color: '#fff', fontSize: 24, fontFamily: 'Inter' },
+  },
+  liveIndicator: {
+    visible: false,
+    text: 'LIVE',
+    blinking: true,
+    color: '#f00',
+    position: { x: 0, y: 0 },
+  },
+  logos: [
+    buildLogo('logo-heavy', largeDataUrl(400)),
+    buildLogo('logo-light', 'data:image/png;base64,small'),
+  ],
+  presets: [],
+  activePresetId: null,
+  targetFPS: 60,
+  quality: 'high',
+  lastImageConfig: { url: largeDataUrl(400), fit: 'cover', position: { x: 0, y: 0 } },
+  keyboardShortcutsVisible: true,
+};
+
+const makeQuotaError = (): DOMException => {
+  // jsdom supports DOMException; fall back to a structurally-similar object otherwise.
+  if (typeof DOMException === 'function') {
+    return new DOMException('quota exceeded', 'QuotaExceededError');
+  }
+  const err = new Error('quota exceeded') as Error & { name: string; code: number };
+  err.name = 'QuotaExceededError';
+  err.code = 22;
+  return err as unknown as DOMException;
+};
+
+describe('localStorageService.saveState quota fallback', () => {
+  let setItemSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setItemSpy = vi.spyOn(window.localStorage, 'setItem');
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('writes the full state once when storage has room', () => {
+    setItemSpy.mockImplementation(() => {});
+
+    localStorageService.saveState(baseState);
+
+    expect(setItemSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).not.toHaveBeenCalled();
+    const written = JSON.parse(setItemSpy.mock.calls[0][1] as string);
+    expect(written.state.logos).toHaveLength(2);
+    expect(written.state.background.type).toBe('image');
+  });
+
+  it('retries with stripped assets when a quota DOMException is thrown', () => {
+    let calls = 0;
+    setItemSpy.mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) throw makeQuotaError();
+    });
+
+    localStorageService.saveState(baseState);
+
+    expect(setItemSpy).toHaveBeenCalledTimes(2);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+
+    const reduced = JSON.parse(setItemSpy.mock.calls[1][1] as string);
+    expect(reduced.state.background.type).toBe('gradient');
+    expect(reduced.state.lastImageConfig).toBeNull();
+    expect(reduced.state.logos).toHaveLength(1);
+    expect(reduced.state.logos[0].id).toBe('logo-light');
+    // Non-asset settings are preserved
+    expect(reduced.state.ticker.animated).toBe(true);
+  });
+
+  it('logs an error and does not retry on non-quota failures', () => {
+    setItemSpy.mockImplementation(() => {
+      throw new Error('disk on fire');
+    });
+
+    localStorageService.saveState(baseState);
+
+    expect(setItemSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/storage/localStorage.ts
+++ b/src/services/storage/localStorage.ts
@@ -1,4 +1,5 @@
-import type { StudioBackground, LowerThird, Ticker, Clock, LiveIndicator, StudioPreset, ImageConfig, LogoConfig, GradientConfig } from '@/types/studio';
+import type { StudioBackground, LowerThird, Ticker, Clock, LiveIndicator, StudioPreset, ImageConfig, LogoConfig } from '@/types/studio';
+import { createDefaultBackground } from '@services/state/defaults';
 
 const STORAGE_KEY = 'virtual-studio-state';
 const STORAGE_VERSION = '1.0';
@@ -13,20 +14,6 @@ const QUOTA_ERROR_NAMES = new Set([
   'QuotaExceededError',
   'NS_ERROR_DOM_QUOTA_REACHED',
 ]);
-
-// Fallback gradient used when an image background must be dropped on quota failure.
-const fallbackGradientBackground: StudioBackground = {
-  id: 'default-bg',
-  type: 'gradient',
-  visible: true,
-  config: {
-    colors: ['#1a1a2e', '#16213e', '#0f3460'],
-    angle: 135,
-    type: 'linear',
-    animated: true,
-    animationSpeed: 0.5,
-  } as GradientConfig,
-};
 
 export interface SavedStudioState {
   background: StudioBackground;
@@ -72,13 +59,14 @@ const isLargeDataUrl = (value: unknown): value is string =>
   value.startsWith('data:') &&
   value.length > DATA_URL_PERSIST_THRESHOLD;
 
-// Replace image backgrounds carrying a stripped data URL with the default gradient,
-// so reload doesn't render an `<img>` with empty src.
+// Replace image backgrounds carrying a stripped data URL with a fresh default
+// gradient (factory call avoids sharing references across multiple stripped
+// backgrounds, which the in-place store updates would otherwise entangle).
 const stripLargeImage = (background: StudioBackground): StudioBackground => {
   if (background.type === 'image' && background.config) {
     const config = background.config as ImageConfig;
     if (isLargeDataUrl(config.url)) {
-      return fallbackGradientBackground;
+      return createDefaultBackground();
     }
   }
   return background;

--- a/src/services/storage/localStorage.ts
+++ b/src/services/storage/localStorage.ts
@@ -1,4 +1,4 @@
-import type { StudioBackground, LowerThird, Ticker, Clock, LiveIndicator, StudioPreset, ImageConfig, LogoConfig } from '@/types/studio';
+import type { StudioBackground, LowerThird, Ticker, Clock, LiveIndicator, StudioPreset, ImageConfig, LogoConfig, GradientConfig } from '@/types/studio';
 
 const STORAGE_KEY = 'virtual-studio-state';
 const STORAGE_VERSION = '1.0';
@@ -6,6 +6,27 @@ const STORAGE_VERSION = '1.0';
 // Data URLs (base64) can be megabytes each. localStorage typically caps at 5-10MB total,
 // so anything above this threshold is dropped on quota fallback to keep settings persisting.
 const DATA_URL_PERSIST_THRESHOLD = 200 * 1024;
+
+// Standard QuotaExceededError DOMException codes across browsers
+const QUOTA_ERROR_CODES = new Set([22, 1014]);
+const QUOTA_ERROR_NAMES = new Set([
+  'QuotaExceededError',
+  'NS_ERROR_DOM_QUOTA_REACHED',
+]);
+
+// Fallback gradient used when an image background must be dropped on quota failure.
+const fallbackGradientBackground: StudioBackground = {
+  id: 'default-bg',
+  type: 'gradient',
+  visible: true,
+  config: {
+    colors: ['#1a1a2e', '#16213e', '#0f3460'],
+    angle: 135,
+    type: 'linear',
+    animated: true,
+    animationSpeed: 0.5,
+  } as GradientConfig,
+};
 
 export interface SavedStudioState {
   background: StudioBackground;
@@ -28,14 +49,22 @@ export interface StorageState {
   state: SavedStudioState;
 }
 
+// Detects browser quota errors without relying on `instanceof Error`. Browsers
+// throw a DOMException for localStorage quota failures, and DOMException is not
+// always a subclass of Error (notably in older WebKit), so check structurally.
 const isQuotaError = (error: unknown): boolean => {
-  if (!(error instanceof Error)) return false;
-  // Different browsers report quota errors differently
-  return (
-    error.name === 'QuotaExceededError' ||
-    error.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
-    /quota/i.test(error.message)
-  );
+  if (typeof error !== 'object' || error === null) return false;
+  const candidate = error as { name?: unknown; code?: unknown; message?: unknown };
+  if (typeof candidate.name === 'string' && QUOTA_ERROR_NAMES.has(candidate.name)) {
+    return true;
+  }
+  if (typeof candidate.code === 'number' && QUOTA_ERROR_CODES.has(candidate.code)) {
+    return true;
+  }
+  if (typeof candidate.message === 'string' && /quota/i.test(candidate.message)) {
+    return true;
+  }
+  return false;
 };
 
 const isLargeDataUrl = (value: unknown): value is string =>
@@ -43,11 +72,13 @@ const isLargeDataUrl = (value: unknown): value is string =>
   value.startsWith('data:') &&
   value.length > DATA_URL_PERSIST_THRESHOLD;
 
+// Replace image backgrounds carrying a stripped data URL with the default gradient,
+// so reload doesn't render an `<img>` with empty src.
 const stripLargeImage = (background: StudioBackground): StudioBackground => {
   if (background.type === 'image' && background.config) {
     const config = background.config as ImageConfig;
     if (isLargeDataUrl(config.url)) {
-      return { ...background, config: { ...config, url: '' } };
+      return fallbackGradientBackground;
     }
   }
   return background;
@@ -62,9 +93,10 @@ const stripHeavyAssets = (state: SavedStudioState): SavedStudioState => ({
     state.lastImageConfig && isLargeDataUrl(state.lastImageConfig.url)
       ? null
       : state.lastImageConfig,
-  logos: state.logos.map((logo) =>
-    isLargeDataUrl(logo.imageUrl) ? { ...logo, imageUrl: '' } : logo
-  ),
+  // Drop logos whose imageUrl can't be persisted entirely — keeping a record with
+  // no imageUrl would leave phantom thumbnails in BrandingControls and an unrenderable
+  // overlay (Logo bails when imageUrl is empty).
+  logos: state.logos.filter((logo) => !isLargeDataUrl(logo.imageUrl)),
   presets: state.presets.map((preset) => ({
     ...preset,
     background: stripLargeImage(preset.background),

--- a/src/services/storage/localStorage.ts
+++ b/src/services/storage/localStorage.ts
@@ -3,6 +3,10 @@ import type { StudioBackground, LowerThird, Ticker, Clock, LiveIndicator, Studio
 const STORAGE_KEY = 'virtual-studio-state';
 const STORAGE_VERSION = '1.0';
 
+// Data URLs (base64) can be megabytes each. localStorage typically caps at 5-10MB total,
+// so anything above this threshold is dropped on quota fallback to keep settings persisting.
+const DATA_URL_PERSIST_THRESHOLD = 200 * 1024;
+
 export interface SavedStudioState {
   background: StudioBackground;
   lowerThird: LowerThird | null;
@@ -24,32 +28,101 @@ export interface StorageState {
   state: SavedStudioState;
 }
 
+const isQuotaError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  // Different browsers report quota errors differently
+  return (
+    error.name === 'QuotaExceededError' ||
+    error.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+    /quota/i.test(error.message)
+  );
+};
+
+const isLargeDataUrl = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  value.startsWith('data:') &&
+  value.length > DATA_URL_PERSIST_THRESHOLD;
+
+const stripLargeImage = (background: StudioBackground): StudioBackground => {
+  if (background.type === 'image' && background.config) {
+    const config = background.config as ImageConfig;
+    if (isLargeDataUrl(config.url)) {
+      return { ...background, config: { ...config, url: '' } };
+    }
+  }
+  return background;
+};
+
+// Returns a state with large embedded data URLs (logos, image backgrounds) removed.
+// Settings are preserved; the user will need to re-upload heavy assets after reload.
+const stripHeavyAssets = (state: SavedStudioState): SavedStudioState => ({
+  ...state,
+  background: stripLargeImage(state.background),
+  lastImageConfig:
+    state.lastImageConfig && isLargeDataUrl(state.lastImageConfig.url)
+      ? null
+      : state.lastImageConfig,
+  logos: state.logos.map((logo) =>
+    isLargeDataUrl(logo.imageUrl) ? { ...logo, imageUrl: '' } : logo
+  ),
+  presets: state.presets.map((preset) => ({
+    ...preset,
+    background: stripLargeImage(preset.background),
+  })),
+});
+
+const buildStorageState = (state: SavedStudioState): StorageState => ({
+  version: STORAGE_VERSION,
+  timestamp: Date.now(),
+  state,
+});
+
+const writeToStorage = (state: SavedStudioState): void => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(buildStorageState(state)));
+};
+
 export const localStorageService = {
-  // Save state to localStorage
-  saveState: (state: { background: StudioBackground; lowerThird: LowerThird | null; ticker: Ticker | null; clock: Clock; liveIndicator: LiveIndicator; logos: LogoConfig[]; presets: StudioPreset[]; activePresetId: string | null; targetFPS: 60 | 30; quality: 'low' | 'medium' | 'high'; lastImageConfig: ImageConfig | null; keyboardShortcutsVisible: boolean }): void => {
+  // Save state to localStorage. On quota errors, retries with heavy assets stripped.
+  saveState: (state: SavedStudioState): void => {
+    const fullState: SavedStudioState = {
+      background: state.background,
+      lowerThird: state.lowerThird,
+      ticker: state.ticker,
+      clock: state.clock,
+      liveIndicator: state.liveIndicator,
+      logos: state.logos,
+      presets: state.presets,
+      activePresetId: state.activePresetId,
+      targetFPS: state.targetFPS,
+      quality: state.quality,
+      lastImageConfig: state.lastImageConfig,
+      keyboardShortcutsVisible: state.keyboardShortcutsVisible,
+    };
+
     try {
-      const storageState: StorageState = {
-        version: STORAGE_VERSION,
-        timestamp: Date.now(),
-        state: {
-          background: state.background,
-          lowerThird: state.lowerThird,
-          ticker: state.ticker,
-          clock: state.clock,
-          liveIndicator: state.liveIndicator,
-          logos: state.logos,
-          presets: state.presets,
-          activePresetId: state.activePresetId,
-          targetFPS: state.targetFPS,
-          quality: state.quality,
-          lastImageConfig: state.lastImageConfig,
-          keyboardShortcutsVisible: state.keyboardShortcutsVisible,
-        }
-      };
-      
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(storageState));
+      writeToStorage(fullState);
+      return;
     } catch (error) {
-      console.error('Failed to save state to localStorage:', error);
+      if (!isQuotaError(error)) {
+        console.error('Failed to save state to localStorage:', error);
+        return;
+      }
+    }
+
+    // Quota exceeded: try again without heavy embedded data URLs.
+    try {
+      writeToStorage(stripHeavyAssets(fullState));
+      console.warn(
+        '⚠️ localStorage quota exceeded. Saved settings without uploaded images/logos; re-upload after reload to restore them.'
+      );
+    } catch (error) {
+      if (isQuotaError(error)) {
+        console.warn(
+          '⚠️ localStorage quota still exceeded after stripping uploaded assets. Settings will not persist this session.'
+        );
+      } else {
+        console.error('Failed to save reduced state to localStorage:', error);
+      }
     }
   },
 
@@ -62,7 +135,7 @@ export const localStorageService = {
       }
 
       const storageState: StorageState = JSON.parse(stored);
-      
+
       // Check version compatibility
       if (storageState.version !== STORAGE_VERSION) {
         console.warn('⚠️ Stored state version mismatch, ignoring saved state');
@@ -109,7 +182,7 @@ export const localStorageService = {
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
       if (!stored) return null;
-      
+
       const storageState: StorageState = JSON.parse(stored);
       return {
         version: storageState.version,


### PR DESCRIPTION
## Summary

Fixes #23.

Toggling ticker animation produced a `QuotaExceededError` and the change appeared not to apply. The toggle itself was fine — the autosave subscriber tried to write the entire studio state (including base64-encoded image backgrounds and uploaded logos, each up to 5 MB) and overflowed the ~5 MB localStorage cap. The state update succeeded in memory, but the visible console error and any reload-time loss made it look like the ticker setting was broken.

## Changes

- `src/services/storage/localStorage.ts`: on `QuotaExceededError`, retry the save with embedded `data:` URLs over 200 KB removed:
  - **Logos** with a heavy `imageUrl` are dropped from the persisted list entirely (keeping a record with no `imageUrl` would leave phantom thumbnails in `BrandingControls` and an unrenderable overlay).
  - **Image backgrounds** with a heavy data URL fall back to the default gradient on persistence (a fresh copy each time, no shared references).
  - **`lastImageConfig`** is cleared when its URL is heavy.
  - Quota detection uses structural checks on `name`/`code`/`message` so it works for `DOMException`s that aren't `instanceof Error`.
- Replaced `console.error` for the quota path with a `console.warn` describing the fallback.
- Extracted the default background into `src/services/state/defaults.ts` so `studioStore` and the quota fallback share one definition.
- Added Vitest coverage in `src/services/storage/__tests__/localStorage.test.ts` for the happy path, the quota retry, and the non-quota error path.

Non-asset settings (ticker config, clock, preset metadata, etc.) keep persisting through the fallback. Heavy assets need to be re-uploaded after reload.

## Test plan

- [x] `npm test -- run src/services/storage/__tests__/localStorage.test.ts` — 3/3 passing.
- [x] `tsc --noEmit -p tsconfig.app.json` clean.
- [ ] Add a large image background and several logos so the saved state exceeds the localStorage quota.
- [ ] Toggle the ticker "Enable Animation" checkbox; verify the ticker animates and no `QuotaExceededError` appears in the console (warning is acceptable).
- [ ] Reload the page: ticker / clock / preset settings persist; image background falls back to the default gradient and heavy logos are gone (expected).
- [ ] With a small state (no large uploads), confirm full state still saves and reloads as before.
