### PR TITLE
Drive ticker scroll with Web Animations API (and drop reduced-motion override)

### DIFF
--- a/src/studio/graphics/Ticker.css
+++ b/src/studio/graphics/Ticker.css
@@ -70,18 +70,8 @@
   flex-shrink: 0;
 }
 
-/* Scrolling animation: the track contains two identical copies of the content,
-   so translating by -50% of the track width slides the second copy into the
-   first copy's exact starting position — restart from 0 is seamless. */
-@keyframes tickerScroll {
-  from { transform: translateX(0); }
-  to   { transform: translateX(-50%); }
-}
-
-/* Pause animation on hover for better readability */
-.ticker-container:hover .ticker-text {
-  animation-play-state: paused !important;
-}
+/* Scrolling is driven by element.animate() in Ticker.tsx — keep CSS animation
+   off so the JS-driven animation isn't overridden. */
 
 /* Alternative ticker styles */
 .ticker-container.style-sports {
@@ -155,19 +145,6 @@
   }
 }
 
-/* Reduced motion */
-@media (prefers-reduced-motion: reduce) {
-  .ticker-text {
-    animation: none !important;
-  }
-  
-  .ticker-content {
-    overflow-x: auto;
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-  }
-  
-  .ticker-content::-webkit-scrollbar {
-    display: none;
-  }
-}
+/* No prefers-reduced-motion override: the ticker is an explicitly-enabled
+   broadcast graphic — when the user turns it on, scrolling is the intended
+   behavior even if the OS requests reduced motion. */

--- a/src/studio/graphics/Ticker.tsx
+++ b/src/studio/graphics/Ticker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef } from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 import type { Ticker as TickerType } from '@/types/studio';
 import './Ticker.css';
 
@@ -22,14 +22,23 @@ export const Ticker: React.FC<TickerProps> = ({ config }) => {
   useLayoutEffect(() => {
     const track = trackRef.current;
     const item = itemRef.current;
+    // When config.visible flips false → true, React unmounts and remounts the
+    // inner DOM, giving us fresh refs. config.visible is in the dep list so
+    // this effect re-runs and attaches the animation to the new track.
     if (!track || !item) return;
+
+    const prefersReducedMotion =
+      typeof window !== 'undefined' &&
+      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
 
     const start = () => {
       if (animationRef.current) {
         animationRef.current.cancel();
         animationRef.current = null;
       }
-      if (!isAnimated) {
+      if (!isAnimated || prefersReducedMotion) {
+        // Static render: text stays in place. Reduced-motion users still see
+        // the headlines, just without continuous scroll.
         track.style.transform = 'translateX(0)';
         return;
       }
@@ -37,15 +46,13 @@ export const Ticker: React.FC<TickerProps> = ({ config }) => {
       if (itemWidth === 0) return;
 
       const speed = Math.max(config.speed, 1);
-      const durationMs = (itemWidth / speed) * 1000;
-
       animationRef.current = track.animate(
         [
           { transform: 'translateX(0)' },
           { transform: `translateX(-${itemWidth}px)` },
         ],
         {
-          duration: durationMs,
+          duration: (itemWidth / speed) * 1000,
           iterations: Infinity,
           easing: 'linear',
         }
@@ -60,39 +67,19 @@ export const Ticker: React.FC<TickerProps> = ({ config }) => {
       document.fonts.ready.then(start).catch(() => {});
     }
 
+    // ResizeObserver covers window resize, container reflow, and any other
+    // size change to the measured item in one path.
+    const ro = new ResizeObserver(start);
+    ro.observe(item);
+
     return () => {
+      ro.disconnect();
       if (animationRef.current) {
         animationRef.current.cancel();
         animationRef.current = null;
       }
     };
-  }, [isAnimated, tickerContent, config.fontSize, config.speed]);
-
-  useEffect(() => {
-    const onResize = () => {
-      const track = trackRef.current;
-      const item = itemRef.current;
-      if (!track || !item || !isAnimated) return;
-      const itemWidth = item.offsetWidth;
-      if (itemWidth === 0) return;
-
-      const speed = Math.max(config.speed, 1);
-      const durationMs = (itemWidth / speed) * 1000;
-
-      if (animationRef.current) {
-        animationRef.current.cancel();
-      }
-      animationRef.current = track.animate(
-        [
-          { transform: 'translateX(0)' },
-          { transform: `translateX(-${itemWidth}px)` },
-        ],
-        { duration: durationMs, iterations: Infinity, easing: 'linear' }
-      );
-    };
-    window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
-  }, [isAnimated, config.speed]);
+  }, [isAnimated, tickerContent, config.fontSize, config.speed, config.visible]);
 
   if (!config.visible || config.content.length === 0) {
     return null;

--- a/src/studio/graphics/Ticker.tsx
+++ b/src/studio/graphics/Ticker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import type { Ticker as TickerType } from '@/types/studio';
 import './Ticker.css';
 
@@ -10,44 +10,93 @@ export const Ticker: React.FC<TickerProps> = ({ config }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const trackRef = useRef<HTMLDivElement>(null);
   const itemRef = useRef<HTMLSpanElement>(null);
-  const [itemWidth, setItemWidth] = useState(0);
+  const animationRef = useRef<Animation | null>(null);
 
   const tickerContent = config.content.join(' • ');
   const isAnimated = config.animated && config.content.length > 0;
 
+  // Drive the scroll with the Web Animations API directly. CSS keyframe +
+  // inline-style approaches were unreliable here — element.animate() pins the
+  // keyframes to the element at known pixel offsets and doesn't depend on CSS
+  // custom properties, percentage transforms, or React style diffing.
   useLayoutEffect(() => {
-    if (!itemRef.current) return;
-    const measure = () => {
-      if (itemRef.current) {
-        setItemWidth(itemRef.current.offsetWidth);
+    const track = trackRef.current;
+    const item = itemRef.current;
+    if (!track || !item) return;
+
+    const start = () => {
+      if (animationRef.current) {
+        animationRef.current.cancel();
+        animationRef.current = null;
+      }
+      if (!isAnimated) {
+        track.style.transform = 'translateX(0)';
+        return;
+      }
+      const itemWidth = item.offsetWidth;
+      if (itemWidth === 0) return;
+
+      const speed = Math.max(config.speed, 1);
+      const durationMs = (itemWidth / speed) * 1000;
+
+      animationRef.current = track.animate(
+        [
+          { transform: 'translateX(0)' },
+          { transform: `translateX(-${itemWidth}px)` },
+        ],
+        {
+          duration: durationMs,
+          iterations: Infinity,
+          easing: 'linear',
+        }
+      );
+    };
+
+    start();
+
+    // Re-measure once fonts have actually loaded — offsetWidth before font
+    // swap returns a fallback-font width that throws off the loop distance.
+    if ('fonts' in document) {
+      document.fonts.ready.then(start).catch(() => {});
+    }
+
+    return () => {
+      if (animationRef.current) {
+        animationRef.current.cancel();
+        animationRef.current = null;
       }
     };
-    measure();
-
-    // Re-measure when fonts finish loading (offsetWidth before font swap is wrong)
-    if ('fonts' in document) {
-      document.fonts.ready.then(measure).catch(() => {});
-    }
-  }, [tickerContent, config.fontSize]);
+  }, [isAnimated, tickerContent, config.fontSize, config.speed]);
 
   useEffect(() => {
-    const handleResize = () => {
-      if (itemRef.current) {
-        setItemWidth(itemRef.current.offsetWidth);
+    const onResize = () => {
+      const track = trackRef.current;
+      const item = itemRef.current;
+      if (!track || !item || !isAnimated) return;
+      const itemWidth = item.offsetWidth;
+      if (itemWidth === 0) return;
+
+      const speed = Math.max(config.speed, 1);
+      const durationMs = (itemWidth / speed) * 1000;
+
+      if (animationRef.current) {
+        animationRef.current.cancel();
       }
+      animationRef.current = track.animate(
+        [
+          { transform: 'translateX(0)' },
+          { transform: `translateX(-${itemWidth}px)` },
+        ],
+        { duration: durationMs, iterations: Infinity, easing: 'linear' }
+      );
     };
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, [isAnimated, config.speed]);
 
   if (!config.visible || config.content.length === 0) {
     return null;
   }
-
-  // Track translates from 0 to -itemWidth (one full copy worth) so the second
-  // copy slides into the first copy's exact starting position — seamless loop.
-  const speed = Math.max(config.speed, 1);
-  const duration = itemWidth > 0 ? itemWidth / speed : 0;
 
   const containerStyle: React.CSSProperties = {
     background: config.backgroundColor,
@@ -55,22 +104,13 @@ export const Ticker: React.FC<TickerProps> = ({ config }) => {
     fontSize: `${config.fontSize}px`,
   };
 
-  const trackStyle: React.CSSProperties = isAnimated && duration > 0
-    ? {
-        animationName: 'tickerScroll',
-        animationDuration: `${duration}s`,
-        animationTimingFunction: 'linear',
-        animationIterationCount: 'infinite',
-      }
-    : { animation: 'none', transform: 'translateX(0)' };
-
   return (
     <div ref={containerRef} className="ticker-container" style={containerStyle}>
       <div className="ticker-label">
         <span>BREAKING</span>
       </div>
       <div className="ticker-content">
-        <div ref={trackRef} className="ticker-text" style={trackStyle}>
+        <div ref={trackRef} className="ticker-text">
           <span ref={itemRef} className="ticker-item">{tickerContent}</span>
           {isAnimated && (
             <span className="ticker-item" aria-hidden="true">{tickerContent}</span>

--- a/src/studio/graphics/Ticker.tsx
+++ b/src/studio/graphics/Ticker.tsx
@@ -27,18 +27,12 @@ export const Ticker: React.FC<TickerProps> = ({ config }) => {
     // this effect re-runs and attaches the animation to the new track.
     if (!track || !item) return;
 
-    const prefersReducedMotion =
-      typeof window !== 'undefined' &&
-      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
-
     const start = () => {
       if (animationRef.current) {
         animationRef.current.cancel();
         animationRef.current = null;
       }
-      if (!isAnimated || prefersReducedMotion) {
-        // Static render: text stays in place. Reduced-motion users still see
-        // the headlines, just without continuous scroll.
+      if (!isAnimated) {
         track.style.transform = 'translateX(0)';
         return;
       }


### PR DESCRIPTION
## Summary

Follow-up to #25 — the user reports the ticker still doesn't animate in production. Two likely causes, both addressed:

1. **`prefers-reduced-motion: reduce` was hard-disabling the animation** with `.ticker-text { animation: none !important; }`. Any user (or browser test profile) with OS-level reduced motion enabled would see no scrolling at all. For a broadcast graphics tool where the user explicitly turns the ticker on, that's the wrong default — they're opting into the motion. Rule removed.
2. **CSS animation + React inline-style approach is too fragile.** Between `prefers-reduced-motion`, the `:hover` pause rule, possible CSS-var scoping quirks, and React's style diffing across renders, there were too many ways the keyframe could fail to fire. Switched to `element.animate()` (Web Animations API). Keyframes are pinned to the element at known pixel offsets (`translateX(0)` → `translateX(-itemWidth)px`), independent of CSS — much harder to suppress.

## Changes

- `src/studio/graphics/Ticker.tsx`: drive the scroll via `element.animate()` in `useLayoutEffect`. Measure the first item's `offsetWidth`, cancel any previous animation, then start a new one with `duration = itemWidth / speed`, `iterations: Infinity`, `easing: 'linear'`. Re-measure once `document.fonts.ready` resolves so the loop distance is correct after font swap. Resize handler re-runs the same flow.
- `src/studio/graphics/Ticker.css`: remove the now-unused `@keyframes tickerScroll`, the CSS-only hover-pause rule (Web Animations API ignores `animation-play-state` from CSS), and the `prefers-reduced-motion` override.

## Test plan

- [x] `tsc --noEmit -p tsconfig.app.json` clean.
- [x] `npm run build` clean.
- [ ] Open the studio, enable the ticker — verify it scrolls smoothly right-to-left.
- [ ] Toggle "Enable Animation" off / on — animation stops, then restarts.
- [ ] Drag the speed slider — perceived speed tracks the value.
- [ ] Verify with OS-level "Reduce motion" enabled (System Settings → Accessibility → Display on macOS, or `prefers-reduced-motion` toggle in Chrome devtools rendering pane) that the ticker still scrolls.
- [ ] Reload page with persisted ticker — animates on load without needing to toggle the checkbox.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D459RSFS5Jhfd5PkdHVkbG)_